### PR TITLE
Remove the assembly scanning workaround

### DIFF
--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
@@ -2,8 +2,6 @@
 {
     using System;
     using System.IO;
-    using System.Reflection;
-    using System.Runtime.Loader;
     using System.Threading;
     using System.Threading.Tasks;
     using AzureFunctions.ServiceBus;
@@ -27,9 +25,9 @@
         {
             endpointFactory = executionContext =>
             {
-                LoadAssemblies(AssemblyDirectoryResolver(executionContext));
-
                 configuration = configurationFactory(executionContext);
+                configuration.EndpointConfiguration.AssemblyScanner().AdditionalAssemblyScanningPath =
+                    AssemblyDirectoryResolver(executionContext);
                 return Endpoint.Start(configuration.EndpointConfiguration);
             };
         }
@@ -218,61 +216,6 @@
             var functionExecutionContext = new FunctionExecutionContext(executionContext, functionsLogger);
 
             await InitializeEndpointIfNecessary(functionExecutionContext).ConfigureAwait(false);
-        }
-
-        internal static void LoadAssemblies(string assemblyDirectory)
-        {
-            var binFiles = Directory.EnumerateFiles(
-                assemblyDirectory,
-                "*.dll",
-                SearchOption.TopDirectoryOnly);
-
-            var assemblyLoadContext = AssemblyLoadContext.GetLoadContext(Assembly.GetExecutingAssembly());
-            foreach (var binFile in binFiles)
-            {
-                try
-                {
-                    var assemblyName = AssemblyName.GetAssemblyName(binFile);
-                    if (IsRuntimeAssembly(assemblyName.GetPublicKeyToken()))
-                    {
-                        continue;
-                    }
-
-                    // LoadFromAssemblyName works when actually running inside a function as FunctionAssemblyLoadContext probes the "bin" folder for the assembly name
-                    // this doesn't work when running with a different AssemblyLoadContext (e.g. tests) and the assembly needs to be loaded by the full path instead.
-                    assemblyLoadContext.LoadFromAssemblyPath(binFile);
-                    //assemblyLoadContext.LoadFromAssemblyName(assemblyName);
-                }
-                catch (Exception e)
-                {
-                    LogManager.GetLogger<FunctionEndpoint>().DebugFormat(
-                        "Failed to load assembly {0}. This error can be ignored if the assembly isn't required to execute the function.{1}{2}",
-                        binFile, Environment.NewLine, e);
-                }
-            }
-        }
-
-        static bool IsRuntimeAssembly(byte[] publicKeyToken)
-        {
-            var tokenString = BitConverter.ToString(publicKeyToken).Replace("-", string.Empty).ToLowerInvariant();
-
-            switch (tokenString)
-            {
-                case "b77a5c561934e089": // Microsoft
-                case "7cec85d7bea7798e":
-                case "b03f5f7f11d50a3a":
-                case "31bf3856ad364e35":
-                case "cc7b13ffcd2ddd51":
-                case "adb9793829ddae60":
-                case "7e34167dcc6d6d8c": // Microsoft.Azure.ServiceBus
-                case "23ec7fc2d6eaa4a5": // Microsoft.Data.SqlClient
-                case "50cebf1cceb9d05e": // Mono.Cecil
-                case "30ad4fe6b2a6aeed": // Newtonsoft.Json
-                case "9fc386479f8a226c": // NServiceBus
-                    return true;
-                default:
-                    return false;
-            }
         }
 
         /// <summary>

--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionEndpoint.cs
@@ -28,6 +28,11 @@
                 configuration = configurationFactory(executionContext);
                 configuration.EndpointConfiguration.AssemblyScanner().AdditionalAssemblyScanningPath =
                     AssemblyDirectoryResolver(executionContext);
+
+                // Third party assembly brought in by Functions SDK that will appear in both NServiceBus base and additional path for assembly scanning.
+                // To avoid exceptions, do not scan it.
+                configuration.AdvancedConfiguration.AssemblyScanner().ExcludeAssemblies(AssembliesToExcludeFromScanning);
+
                 return Endpoint.Start(configuration.EndpointConfiguration);
             };
         }
@@ -224,6 +229,8 @@
         /// </summary>
         protected Func<FunctionExecutionContext, string> AssemblyDirectoryResolver = functionExecutionContext =>
             Path.Combine(functionExecutionContext.ExecutionContext.FunctionAppDirectory, "bin");
+
+        internal static readonly string[] AssembliesToExcludeFromScanning = { "NCrontab.Signed.dll" };
 
         readonly Func<FunctionExecutionContext, Task<IEndpointInstance>> endpointFactory;
 

--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -34,6 +34,10 @@
         {
             configuration.EndpointConfiguration.AssemblyScanner().AdditionalAssemblyScanningPath = appDirectory;
 
+            // Third party assembly brought in by Functions SDK that will appear in both NServiceBus base and additional path for assembly scanning.
+            // To avoid exceptions, do not scan it.
+            configuration.AdvancedConfiguration.AssemblyScanner().ExcludeAssemblies(FunctionEndpoint.AssembliesToExcludeFromScanning);
+
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(
                     configuration.EndpointConfiguration,
                     serviceCollection);

--- a/src/NServiceBus.AzureFunctions.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -32,7 +32,7 @@
             IServiceCollection serviceCollection,
             string appDirectory)
         {
-            FunctionEndpoint.LoadAssemblies(appDirectory);
+            configuration.EndpointConfiguration.AssemblyScanner().AdditionalAssemblyScanningPath = appDirectory;
 
             var startableEndpoint = EndpointWithExternallyManagedContainer.Create(
                     configuration.EndpointConfiguration,


### PR DESCRIPTION
Removes the workaround as core allows specifying additional scanning directories.

~~Note, this doesn't work currently due to Core also scanning the functions tooling folder, causing conflicts with already loaded assemblies.~~ The following [commit](https://github.com/Particular/NServiceBus.AzureFunctions.ServiceBus/pull/141/commits/f77d99b1511d09c70569ae8e532b17397eb3d7e8) fixes it.