### PR TITLE
Do not require connection string environment variable

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
@@ -1,5 +1,6 @@
 ﻿namespace NServiceBus.AzureFunctions.InProcess.ServiceBus
 {
+    using System;
     using Settings;
     using Transport;
 
@@ -13,10 +14,23 @@
 
         public override string ExampleConnectionStringForErrorMessage { get; } = string.Empty;
 
-        public override bool RequiresConnectionString => baseTransport.RequiresConnectionString;
+        // HINT: Prevent core from throwing a generic exception
+        public override bool RequiresConnectionString => false;
 
         public override TransportInfrastructure Initialize(SettingsHolder settings, string connectionString)
         {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new Exception($@"Azure Service Bus connection string has not been configured.
+
+Specify a connection string using:
+
+  serviceBusTriggeredEndpointConfiguration.Transport.ConnectionString(connectionString);
+
+or
+
+  an environment variable named {ServiceBusTriggeredEndpointConfiguration.DefaultServiceBusConnectionName}");
+            }
             var baseTransportInfrastructure = baseTransport.Initialize(settings, connectionString);
             return new ServerlessTransportInfrastructure(baseTransportInfrastructure, settings);
         }

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -49,7 +49,15 @@
 
             var connectionString =
                 Environment.GetEnvironmentVariable(connectionStringName ?? DefaultServiceBusConnectionName);
-            Transport.ConnectionString(connectionString);
+            if (!string.IsNullOrWhiteSpace(connectionString))
+            {
+                Transport.ConnectionString(connectionString);
+            }
+            else if (!string.IsNullOrWhiteSpace(connectionStringName))
+            {
+                throw new Exception(
+                    $"Connection string not found. Make sure the Service Bus connection string is stored in an environment variable named {connectionStringName}.");
+            }
 
             var recoverability = AdvancedConfiguration.Recoverability();
             recoverability.Immediate(settings => settings.NumberOfRetries(5));

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -56,7 +56,7 @@
             else if (!string.IsNullOrWhiteSpace(connectionStringName))
             {
                 throw new Exception(
-                    $"Connection string not found. Make sure the Service Bus connection string is stored in an environment variable named {connectionStringName}.");
+                    $"Azure Service Bus connection string named '{connectionStringName}' was provided but wasn't found in the environment variables. Make sure the connection string is stored in the environment variable named '{connectionStringName}'.");
             }
 
             var recoverability = AdvancedConfiguration.Recoverability();

--- a/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
+++ b/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
@@ -1,0 +1,26 @@
+﻿namespace ServiceBus.Tests
+{
+    using System;
+    using NServiceBus;
+    using NServiceBus.AzureFunctions.InProcess.ServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_no_connection_string_is_provided
+    {
+        [Test]
+        public void Should_guide_user_towards_success()
+        {
+            var endpointConfiguration = new EndpointConfiguration("SampleEndpoint");
+            endpointConfiguration.UseTransport<ServerlessTransport<AzureServiceBusTransport>>();
+
+            var exception = Assert.ThrowsAsync<Exception>(
+                () => Endpoint.Create(endpointConfiguration),
+                "Exception should be thrown at endpoint creation so that the error will be found during functions startup"
+            );
+
+            StringAssert.Contains(".Transport.ConnectionString(", exception?.Message, "Should mention the transport extension approach");
+            StringAssert.Contains("environment variable", exception?.Message, "Should mention the environment variable approach");
+        }
+    }
+}

--- a/src/ServiceBus.Tests/When_providing_missing_connection_string_name.cs
+++ b/src/ServiceBus.Tests/When_providing_missing_connection_string_name.cs
@@ -1,0 +1,22 @@
+﻿namespace ServiceBus.Tests
+{
+    using System;
+    using NServiceBus;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class When_providing_missing_connection_string_name
+    {
+        [Test]
+        public void Should_guide_user_towards_success()
+        {
+            var exception = Assert.Throws<Exception>(() =>
+                    new ServiceBusTriggeredEndpointConfiguration("SampleEndpoint", "DOES_NOT_EXIST"),
+                "Exception should be thrown in constructor so that the error will be found during functions startup"
+            );
+
+            StringAssert.Contains("environment variable", exception?.Message, "Should mention that there's a missing environment variable");
+            StringAssert.Contains("DOES_NOT_EXIST", exception?.Message, "Should mention the specific environment variable");
+        }
+    }
+}


### PR DESCRIPTION
Resolves #232

If there are functions with a Service Bus trigger then the Azure Functions infrastructure requires that the Service Bus connection string is available in an environment variable, and the NServiceBus endpoint must use this same connection string.

If there are no functions with a Service Bus trigger then the environment variable is not required and the NServiceBus endpoint connection string can be configured using an alternative mechanism. For example:

```csharp
class Startup : FunctionsStartup
{
    public override void Configure(IFunctionsHostBuilder builder)
    {
        var configuration = builder.GetContext().Configuration;
        builder.UseNServiceBus(() =>
        {
            var config = new ServiceBusTriggeredEndpointConfiguration("MyEndpoint");
            config.Transport.ConnectionString(configuration.GetConnectionString("MyConnection"));
            return config;
        });
    }
}
```