### PR TITLE
Use IConfiguration to setup endpoint

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -3,6 +3,7 @@
     using System;
     using System.IO;
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>
@@ -10,6 +11,16 @@
     /// </summary>
     public static class FunctionsHostBuilderExtensions
     {
+        /// <summary>
+        /// Use the IConfiguration to configures an NServiceBus endpoint that can be injected into a function trigger as a <see cref="FunctionEndpoint"/> via dependency injection.
+        /// </summary>
+        public static void UseNServiceBus(
+            this IFunctionsHostBuilder functionsHostBuilder)
+        {
+            functionsHostBuilder.UseNServiceBus(() => new ServiceBusTriggeredEndpointConfiguration(
+                functionsHostBuilder.GetContext().Configuration));
+        }
+
         /// <summary>
         /// Configures an NServiceBus endpoint that can be injected into a function trigger as a <see cref="FunctionEndpoint"/> via dependency injection.
         /// </summary>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -3,7 +3,6 @@
     using System;
     using System.IO;
     using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
 
     /// <summary>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/Serverless/TransportWrapper/ServerlessTransport.cs
@@ -21,15 +21,8 @@
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
-                throw new Exception($@"Azure Service Bus connection string has not been configured.
-
-Specify a connection string using:
-
-  serviceBusTriggeredEndpointConfiguration.Transport.ConnectionString(connectionString);
-
-or
-
-  an environment variable named {ServiceBusTriggeredEndpointConfiguration.DefaultServiceBusConnectionName}");
+                throw new Exception($@"Azure Service Bus connection string has not been configured. Specify a connection string through IConfiguration, an environment variable named {ServiceBusTriggeredEndpointConfiguration.DefaultServiceBusConnectionName} or using:
+  serviceBusTriggeredEndpointConfiguration.Transport.ConnectionString(connectionString);");
             }
             var baseTransportInfrastructure = baseTransport.Initialize(settings, connectionString);
             return new ServerlessTransportInfrastructure(baseTransportInfrastructure, settings);

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -84,12 +84,9 @@
             {
                 Transport.ConnectionString(connectionString);
             }
-            else
+            else if (!string.IsNullOrWhiteSpace(connectionStringName))
             {
-                var message = connectionStringName != null ?
-                    $"Azure Service Bus connection string named '{connectionStringName}' was provided but wasn't found in the environment variables. Make sure the connection string is stored in the environment variable named '{connectionStringName}'." :
-                    "Azure Service Bus connection string was not provided.";
-                throw new Exception(message);
+                throw new Exception($"Azure Service Bus connection string named '{connectionStringName}' was provided but wasn't found in the environment variables. Make sure the connection string is stored in the environment variable named '{connectionStringName}'.");
             }
 
             var recoverability = AdvancedConfiguration.Recoverability();

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -10,7 +10,7 @@
     using Transport;
 
     /// <summary>
-    /// Represents a serverless NServiceBus endpoint running within an AzureServiceBus trigger.
+    /// Represents a serverless NServiceBus endpoint.
     /// </summary>
     public class ServiceBusTriggeredEndpointConfiguration
     {
@@ -20,7 +20,7 @@
         }
 
         /// <summary>
-        /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger
+        /// Creates a serverless NServiceBus endpoint.
         /// </summary>
         public ServiceBusTriggeredEndpointConfiguration(IConfiguration configuration)
             : this(GetConfiguredValueOrFallback(configuration, "ENDPOINT_NAME", optional: false), configuration)
@@ -28,7 +28,7 @@
         }
 
         /// <summary>
-        /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger
+        /// Creates a serverless NServiceBus endpoint.
         /// </summary>
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, IConfiguration configuration = null)
             : this(endpointName, null, configuration)
@@ -36,7 +36,7 @@
         }
 
         /// <summary>
-        /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
+        /// Creates a serverless NServiceBus endpoint.
         /// </summary>
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = null)
             : this(endpointName, connectionStringName, null)
@@ -44,7 +44,7 @@
         }
 
         /// <summary>
-        /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
+        /// Creates a serverless NServiceBus endpoint.
         /// </summary>
         public ServiceBusTriggeredEndpointConfiguration(string endpointName)
             : this(endpointName, null, null)
@@ -52,7 +52,7 @@
         }
 
         /// <summary>
-        /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger.
+        /// Creates a serverless NServiceBus endpoint.
         /// </summary>
         internal ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = null, IConfiguration configuration = null)
         {

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -22,6 +22,14 @@
         /// <summary>
         /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger
         /// </summary>
+        public ServiceBusTriggeredEndpointConfiguration(IConfiguration configuration)
+            : this(GetConfiguredValueOrFallback(configuration, "ENDPOINT_NAME", optional: false), configuration)
+        {
+        }
+
+        /// <summary>
+        /// Creates a serverless NServiceBus endpoint running within an Azure Service Bus trigger
+        /// </summary>
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, IConfiguration configuration = null)
             : this(endpointName, null, configuration)
         {
@@ -91,7 +99,7 @@
             EndpointConfiguration.UseSerialization<NewtonsoftSerializer>();
         }
 
-        string GetConfiguredValueOrFallback(IConfiguration configuration, string key, bool optional)
+        static string GetConfiguredValueOrFallback(IConfiguration configuration, string key, bool optional)
         {
             if (configuration != null)
             {

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -53,6 +53,8 @@ namespace NServiceBus
     }
     public class ServiceBusTriggeredEndpointConfiguration
     {
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName) { }
+        public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Configuration.IConfiguration configuration = null) { }
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = null) { }
         public NServiceBus.EndpointConfiguration AdvancedConfiguration { get; }
         public NServiceBus.TransportExtensions<NServiceBus.AzureServiceBusTransport> Transport { get; }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -25,6 +25,7 @@ namespace NServiceBus
     }
     public static class FunctionsHostBuilderExtensions
     {
+        public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
         public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, System.Func<NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
     }
     public interface IFunctionEndpoint
@@ -53,6 +54,7 @@ namespace NServiceBus
     }
     public class ServiceBusTriggeredEndpointConfiguration
     {
+        public ServiceBusTriggeredEndpointConfiguration(Microsoft.Extensions.Configuration.IConfiguration configuration) { }
         public ServiceBusTriggeredEndpointConfiguration(string endpointName) { }
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, Microsoft.Extensions.Configuration.IConfiguration configuration = null) { }
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = null) { }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -25,7 +25,7 @@ namespace NServiceBus
     }
     public static class FunctionsHostBuilderExtensions
     {
-        public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, Microsoft.Extensions.Configuration.IConfiguration configuration) { }
+        public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder) { }
         public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, System.Func<NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
     }
     public interface IFunctionEndpoint

--- a/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
+++ b/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
@@ -12,6 +12,9 @@
         public void Should_guide_user_towards_success()
         {
             var endpointConfiguration = new EndpointConfiguration("SampleEndpoint");
+            var scanner = endpointConfiguration.AssemblyScanner();
+            scanner.ThrowExceptions = false;
+
             endpointConfiguration.UseTransport<ServerlessTransport<AzureServiceBusTransport>>();
 
             var exception = Assert.ThrowsAsync<Exception>(

--- a/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
+++ b/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
@@ -12,8 +12,6 @@
         public void Should_guide_user_towards_success()
         {
             var endpointConfiguration = new EndpointConfiguration("SampleEndpoint");
-            var scanner = endpointConfiguration.AssemblyScanner();
-            scanner.ThrowExceptions = false;
 
             endpointConfiguration.UseTransport<ServerlessTransport<AzureServiceBusTransport>>();
 

--- a/src/ServiceBus.Tests/When_providing_missing_connection_string_name.cs
+++ b/src/ServiceBus.Tests/When_providing_missing_connection_string_name.cs
@@ -5,13 +5,13 @@
     using NUnit.Framework;
 
     [TestFixture]
-    public class When_providing_missing_connection_string_name
+    public class When_providing_connection_string_name_with_missing_value
     {
         [Test]
         public void Should_guide_user_towards_success()
         {
             var exception = Assert.Throws<Exception>(() =>
-                    new ServiceBusTriggeredEndpointConfiguration("SampleEndpoint", "DOES_NOT_EXIST"),
+                _ = new ServiceBusTriggeredEndpointConfiguration("SampleEndpoint", "DOES_NOT_EXIST"),
                 "Exception should be thrown in constructor so that the error will be found during functions startup"
             );
 


### PR DESCRIPTION
Closes #95 

More broadly uses IConfiguration to set up the endpoint.

```
class Startup : FunctionsStartup
{
    public override void Configure(IFunctionsHostBuilder builder)
    {
        builder.UseNServiceBus();
    }
}
```

Will need to apply on top of https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/pull/235 when it is merged.