### PR TITLE
Use single process implementation

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionEndpoint.cs
@@ -94,6 +94,8 @@
             await InitializeEndpointIfNecessary(functionExecutionContext, CancellationToken.None)
                 .ConfigureAwait(false);
 
+            var messageId = message.GetMessageId();
+
             try
             {
                 using (var transaction = transactionFactory())
@@ -116,7 +118,7 @@
                     var errorContext = new ErrorContext(
                         exception,
                         message.GetHeaders(),
-                        message.MessageId,
+                        messageId,
                         message.Body,
                         transportTransaction,
                         message.SystemProperties.DeliveryCount);
@@ -137,7 +139,7 @@
 
             MessageContext CreateMessageContext(TransportTransaction transportTransaction) =>
                 new MessageContext(
-                    message.GetMessageId(),
+                    messageId,
                     message.GetHeaders(),
                     message.Body,
                     transportTransaction,

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionEndpoint.cs
@@ -104,7 +104,7 @@
                     await pipeline.PushMessage(messageContext).ConfigureAwait(false);
 
                     await onComplete(transaction).ConfigureAwait(false);
-                    //await messageReceiver.SafeCompleteAsync(message, transaction).ConfigureAwait(false);
+
                     transaction?.Commit();
                 }
             }

--- a/src/ServiceBus.Tests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.Tests/FunctionEndpointComponent.cs
@@ -2,20 +2,14 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.ServiceBus;
     using Microsoft.Extensions.DependencyInjection;
     using NServiceBus;
     using NServiceBus.AcceptanceTesting;
     using NServiceBus.AcceptanceTesting.Customization;
     using NServiceBus.AcceptanceTesting.Support;
-    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
-    using NServiceBus.Serialization;
-    using NServiceBus.Settings;
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
 
     abstract class FunctionEndpointComponent : IComponentBehavior
@@ -57,9 +51,6 @@
                 this.scenarioContext = scenarioContext;
                 this.functionComponentType = functionComponentType;
                 Name = functionComponentType.FullName;
-
-                var serializer = new NewtonsoftSerializer();
-                messageSerializer = serializer.Configure(new SettingsHolder())(new MessageMapper());
             }
 
             public override string Name { get; }
@@ -107,7 +98,7 @@
             {
                 foreach (var message in messages)
                 {
-                    var transportMessage = GenerateMessage(message);
+                    var transportMessage = MessageHelper.GenerateMessage(message);
                     var context = new ExecutionContext();
                     await endpoint.Process(transportMessage, context);
                 }
@@ -123,37 +114,11 @@
                 return base.Stop();
             }
 
-            Message GenerateMessage(object message)
-            {
-                Message asbMessage;
-                using (var stream = new MemoryStream())
-                {
-                    messageSerializer.Serialize(message, stream);
-                    asbMessage = new Message(stream.ToArray());
-                }
-
-                asbMessage.UserProperties["NServiceBus.EnclosedMessageTypes"] = message.GetType().FullName;
-
-                var systemProperties = new Message.SystemPropertiesCollection();
-                // sequence number is required to prevent SystemPropertiesCollection from throwing on the getters
-                var fieldInfo = typeof(Message.SystemPropertiesCollection).GetField("sequenceNumber", BindingFlags.NonPublic | BindingFlags.Instance);
-                fieldInfo.SetValue(systemProperties, 123);
-                // set delivery count to 1
-                var deliveryCountProperty = typeof(Message.SystemPropertiesCollection).GetProperty("DeliveryCount");
-                deliveryCountProperty.SetValue(systemProperties, 1);
-                // assign test message mocked system properties
-                var property = typeof(Message).GetProperty("SystemProperties");
-                property.SetValue(asbMessage, systemProperties);
-
-                return asbMessage;
-            }
-
             readonly Action<ServiceBusTriggeredEndpointConfiguration> configurationCustomization;
             readonly ScenarioContext scenarioContext;
             readonly Type functionComponentType;
             IList<object> messages;
             FunctionEndpoint endpoint;
-            IMessageSerializer messageSerializer;
         }
     }
 }

--- a/src/ServiceBus.Tests/FunctionEndpointTests.cs
+++ b/src/ServiceBus.Tests/FunctionEndpointTests.cs
@@ -1,0 +1,169 @@
+﻿namespace ServiceBus.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using NServiceBus;
+    using NServiceBus.AzureFunctions.InProcess.ServiceBus;
+    using NServiceBus.Transport;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class FunctionEndpointTests
+    {
+        [Test]
+        public async Task When_processing_successful_should_complete_message()
+        {
+            var onCompleteCalled = false;
+            var message = MessageHelper.GenerateMessage(new TestMessage());
+            MessageContext messageContext = null;
+            TransportTransaction transportTransaction = null;
+            var pipelineInvoker = await CreatePipeline(
+                ctx =>
+                {
+                    messageContext = ctx;
+                    return Task.CompletedTask;
+                });
+
+
+            await FunctionEndpoint.Process(
+                message,
+                tx =>
+                {
+                    onCompleteCalled = true;
+                    return Task.CompletedTask;
+                }, () => null,
+                _ => transportTransaction = new TransportTransaction(),
+                pipelineInvoker);
+
+            Assert.IsTrue(onCompleteCalled);
+            Assert.AreSame(message.GetMessageId(), messageContext.MessageId);
+            Assert.AreSame(message.Body, messageContext.Body);
+            CollectionAssert.IsSubsetOf(message.GetHeaders(), messageContext.Headers); // the IncomingMessage has an additional MessageId header
+            Assert.AreSame(transportTransaction, messageContext.TransportTransaction);
+        }
+
+        [Test]
+        public async Task When_processing_fails_should_provide_error_context()
+        {
+            var message = MessageHelper.GenerateMessage(new TestMessage());
+            var pipelineException = new Exception("test exception");
+            var transportTransactions = new List<TransportTransaction>();
+            ErrorContext errorContext = null;
+            var pipelineInvoker = await CreatePipeline(
+                _ => throw pipelineException,
+                errCtx =>
+                {
+                    errorContext = errCtx;
+                    return Task.FromResult(ErrorHandleResult.Handled);
+                });
+
+            await FunctionEndpoint.Process(
+                message,
+                tx => Task.CompletedTask,
+                () => null,
+                _ =>
+                {
+                    var tx = new TransportTransaction();
+                    transportTransactions.Add(tx);
+                    return tx;
+                },
+                pipelineInvoker);
+
+            Assert.AreSame(pipelineException, errorContext.Exception);
+            Assert.AreSame(message.GetMessageId(), errorContext.Message.NativeMessageId);
+            Assert.AreSame(message.Body, errorContext.Message.Body);
+            CollectionAssert.IsSubsetOf(message.GetHeaders(), errorContext.Message.Headers); // the IncomingMessage has an additional MessageId header
+            Assert.AreSame(transportTransactions.Last(), errorContext.TransportTransaction); // verify usage of the correct transport transaction instance
+            Assert.AreEqual(2, transportTransactions.Count); // verify that a new transport transaction has been created for the error handling
+        }
+
+        [Test]
+        public async Task When_error_pipeline_fails_should_throw()
+        {
+            var onCompleteCalled = false;
+            var errorPipelineException = new Exception("error pipeline failure");
+            var pipelineInvoker = await CreatePipeline(
+                _ => throw new Exception("main pipeline failure"),
+                _ => throw errorPipelineException);
+
+            var exception = Assert.ThrowsAsync<Exception>(async () =>
+                await FunctionEndpoint.Process(
+                    MessageHelper.GenerateMessage(new TestMessage()),
+                    tx =>
+                    {
+                        onCompleteCalled = true;
+                        return Task.CompletedTask;
+                    },
+                    () => null,
+                    _ => new TransportTransaction(),
+                    pipelineInvoker));
+
+            Assert.IsFalse(onCompleteCalled);
+            Assert.AreSame(errorPipelineException, exception);
+        }
+
+        [Test]
+        public async Task When_error_pipeline_handles_error_should_complete_message()
+        {
+            var onCompleteCalled = false;
+            var pipelineInvoker = await CreatePipeline(
+                _ => throw new Exception("main pipeline failure"),
+                _ => Task.FromResult(ErrorHandleResult.Handled));
+
+            await FunctionEndpoint.Process(
+                MessageHelper.GenerateMessage(new TestMessage()),
+                tx =>
+                {
+                    onCompleteCalled = true;
+                    return Task.CompletedTask;
+                },
+                () => null,
+                _ => new TransportTransaction(),
+                pipelineInvoker);
+
+            Assert.IsTrue(onCompleteCalled);
+        }
+
+        [Test]
+        public async Task When_error_pipeline_requires_retry_should_throw()
+        {
+            var onCompleteCalled = false;
+            var mainPipelineException = new Exception("main pipeline failure");
+            var pipelineInvoker = await CreatePipeline(
+                _ => throw mainPipelineException,
+                _ => Task.FromResult(ErrorHandleResult.RetryRequired));
+
+            var exception = Assert.ThrowsAsync<Exception>(async () =>
+                await FunctionEndpoint.Process(
+                    MessageHelper.GenerateMessage(new TestMessage()),
+                    tx =>
+                    {
+                        onCompleteCalled = true;
+                        return Task.CompletedTask;
+                    },
+                    () => null,
+                    _ => new TransportTransaction(),
+                    pipelineInvoker));
+
+            Assert.IsFalse(onCompleteCalled);
+            Assert.AreSame(mainPipelineException, exception);
+        }
+
+        static async Task<PipelineInvoker> CreatePipeline(Func<MessageContext, Task> mainPipeline = null, Func<ErrorContext, Task<ErrorHandleResult>> errorPipeline = null)
+        {
+            var pipelineInvoker = new PipelineInvoker();
+            await (pipelineInvoker as IPushMessages)
+                .Init(
+                    mainPipeline ?? (_ => Task.CompletedTask),
+                    errorPipeline ?? (_ => Task.FromResult(ErrorHandleResult.Handled)),
+                    null, null);
+            return pipelineInvoker;
+        }
+
+        class TestMessage
+        {
+        }
+    }
+}

--- a/src/ServiceBus.Tests/MessageHelper.cs
+++ b/src/ServiceBus.Tests/MessageHelper.cs
@@ -1,0 +1,43 @@
+﻿namespace ServiceBus.Tests
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+    using Microsoft.Azure.ServiceBus;
+    using NServiceBus;
+    using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+    using NServiceBus.Serialization;
+    using NServiceBus.Settings;
+
+    public class MessageHelper
+    {
+        static NewtonsoftSerializer serializer = new NewtonsoftSerializer();
+        static IMessageSerializer messageSerializer = serializer.Configure(new SettingsHolder())(new MessageMapper());
+
+        public static Message GenerateMessage(object message)
+        {
+            Message asbMessage;
+            using (var stream = new MemoryStream())
+            {
+                messageSerializer.Serialize(message, stream);
+                asbMessage = new Message(stream.ToArray());
+            }
+
+            asbMessage.UserProperties["NServiceBus.EnclosedMessageTypes"] = message.GetType().FullName;
+
+            var systemProperties = new Message.SystemPropertiesCollection();
+            // sequence number is required to prevent SystemPropertiesCollection from throwing on the getters
+            var fieldInfo = typeof(Message.SystemPropertiesCollection).GetField("sequenceNumber", BindingFlags.NonPublic | BindingFlags.Instance);
+            fieldInfo.SetValue(systemProperties, 123);
+            // set delivery count to 1
+            var deliveryCountProperty = typeof(Message.SystemPropertiesCollection).GetProperty("DeliveryCount");
+            deliveryCountProperty.SetValue(systemProperties, 1);
+            // assign test message mocked system properties
+            var property = typeof(Message).GetProperty("SystemProperties");
+            property.SetValue(asbMessage, systemProperties);
+
+            asbMessage.MessageId = Guid.NewGuid().ToString("N");
+            return asbMessage;
+        }
+    }
+}


### PR DESCRIPTION
Refactoring attmept to use a single "Process" implementation by both transactional and non-transactional methods. Potentially opening up for more public `Process` overloads that can determine transactional/non-transactional behavior at runtime.

Not sure I really like the generalization, the amount of callbacks to handle the tx handling is quite ugly over the benefit of a single code path.

Thoughts?