### PR TITLE
Propose configuration overload

### DIFF
--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -27,6 +27,7 @@ namespace NServiceBus
     {
         public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder) { }
         public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, System.Func<NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
+        public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, System.Func<Microsoft.Extensions.Configuration.IConfiguration, NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory) { }
     }
     public interface IFunctionEndpoint
     {


### PR DESCRIPTION
A proposal for #236 to add one additional overload that passes `IConfiguration` to the `ServiceBusTriggeredEndpoint` factory method. This allows a user to rely on the configuration without having to know how to get it from the functions startup context.