### PR TITLE
Deprecate static hosting method

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -131,6 +131,10 @@
         /// Attempts to derive the required configuration parameters automatically from the Azure Functions related attributes via
         /// reflection.
         /// </summary>
+        [ObsoleteEx(
+            Message = "The static hosting model has been deprecated. Refer to the documentation for details on how to use class-instance approach instead.",
+            RemoveInVersion = "3",
+            TreatAsErrorFromVersion = "2")]
         public static ServiceBusTriggeredEndpointConfiguration FromAttributes()
         {
             var serviceBusTriggerAttribute = ReflectionHelper.FindBusTriggerAttribute();

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -84,6 +84,9 @@ namespace NServiceBus
             where T : NServiceBus.Serialization.SerializationDefinition, new () { }
         protected NServiceBus.TransportExtensions<TTransport> UseTransport<TTransport>()
             where TTransport : NServiceBus.Transport.TransportDefinition, new () { }
+        [System.Obsolete("The static hosting model has been deprecated. Refer to the documentation for deta" +
+            "ils on how to use class-instance approach instead. Will be treated as an error f" +
+            "rom version 2.0.0. Will be removed in version 3.0.0.", false)]
         public static NServiceBus.ServiceBusTriggeredEndpointConfiguration FromAttributes() { }
     }
 }


### PR DESCRIPTION
When the NServiceBus.AzureFunctions.InProcess.ServiceBus package was [released as 1.0](https://particular.net/blog/nservicebus-with-azure-functions-turns-1-0), the static hosting method was deprecated. This static constructor method was not removed at that time and cannot be used in any other context.

See [Azure Functions with Azure Service Bus](https://docs.particular.net/nservicebus/hosting/azure-functions/service-bus) in the documentation for how to host NServiceBus within an Azure Function.