### PR TITLE
Rename EnableCrossEntityTransactions attribute property

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBusTriggerFunctionAttribute.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBusTriggerFunctionAttribute.cs
@@ -18,9 +18,9 @@
         public string TriggerFunctionName { get; set; }
 
         /// <summary>
-        /// Enable cross-entity transactions.
+        /// Enable Azure Service Bus transactions to provide <see cref="TransportTransactionMode.SendsAtomicWithReceive"/> transport guarantees.
         /// </summary>
-        public bool EnableCrossEntityTransactions { get; set; }
+        public bool SendsAtomicWithReceive { get; set; }
 
         /// <summary>
         /// Endpoint logical name.

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/SourceGeneratorApproval2.cs
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/SourceGeneratorApproval2.cs
@@ -132,7 +132,7 @@ using NServiceBus;
             var source = @"
 using NServiceBus;
 
-[assembly: NServiceBusTriggerFunction(""endpoint"", EnableCrossEntityTransactions = true)]
+[assembly: NServiceBusTriggerFunction(""endpoint"", SendsAtomicWithReceive = true)]
 
 public class Startup
 {
@@ -148,7 +148,7 @@ public class Startup
             var source = @"
 using NServiceBus;
 
-[assembly: NServiceBusTriggerFunction(""endpoint"", TriggerFunctionName = ""trigger"", EnableCrossEntityTransactions = true)]
+[assembly: NServiceBusTriggerFunction(""endpoint"", TriggerFunctionName = ""trigger"", SendsAtomicWithReceive = true)]
 
 public class Startup
 {
@@ -164,7 +164,7 @@ public class Startup
             var source = @"
 using NServiceBus;
 
-[assembly: NServiceBusTriggerFunction(""endpoint"", EnableCrossEntityTransactions = true, TriggerFunctionName = ""trigger"")]
+[assembly: NServiceBusTriggerFunction(""endpoint"", SendsAtomicWithReceive = true, TriggerFunctionName = ""trigger"")]
 
 public class Startup
 {

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -66,8 +66,8 @@ namespace NServiceBus
     public sealed class NServiceBusTriggerFunctionAttribute : System.Attribute
     {
         public NServiceBusTriggerFunctionAttribute(string endpointName) { }
-        public bool EnableCrossEntityTransactions { get; set; }
         public string EndpointName { get; }
+        public bool SendsAtomicWithReceive { get; set; }
         public string TriggerFunctionName { get; set; }
     }
     public class ServiceBusTriggeredEndpointConfiguration


### PR DESCRIPTION
To match better with existing transport setting names.