### PR TITLE
Change routing configuration type

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -4,6 +4,7 @@
     using System.Threading;
     using System.Threading.Tasks;
     using AzureFunctions.InProcess.ServiceBus;
+    using Configuration.AdvancedExtensibility;
     using Logging;
     using Microsoft.Extensions.Configuration;
     using Serialization;
@@ -29,7 +30,7 @@
         /// <summary>
         /// The routing configuration.
         /// </summary>
-        public RoutingSettings Routing { get; }
+        public RoutingSettings<AzureServiceBusTransport> Routing { get; }
 
         /// <summary>
         /// Gives access to the underlying endpoint configuration for advanced configuration options.
@@ -83,7 +84,8 @@
             Transport = new AzureServiceBusTransport(connectionString ?? "missing"); // connection string will be checked before creating the startable endpoint as it might be configured within UseNServiceBus().
 
             serverlessTransport = new ServerlessTransport(Transport);
-            Routing = endpointConfiguration.UseTransport(serverlessTransport);
+            var serverlessRouting = endpointConfiguration.UseTransport(serverlessTransport);
+            Routing = new RoutingSettings<AzureServiceBusTransport>(serverlessRouting.GetSettings());
 
             endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
 

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -91,7 +91,7 @@ namespace NServiceBus
             " Will be removed in version 3.0.0.", true)]
         public ServiceBusTriggeredEndpointConfiguration(string endpointName, string connectionStringName = null) { }
         public NServiceBus.EndpointConfiguration AdvancedConfiguration { get; }
-        public NServiceBus.RoutingSettings Routing { get; }
+        public NServiceBus.RoutingSettings<NServiceBus.AzureServiceBusTransport> Routing { get; }
         public string ServiceBusConnectionString { get; set; }
         public NServiceBus.AzureServiceBusTransport Transport { get; }
         public void DoNotSendMessagesToErrorQueue() { }


### PR DESCRIPTION
return the more specific `RoutingSettings<AzureServiceBusTransport>` type for the routing config. This might be useful/necessary if ASB transport provides additional, transport specific, routing extensions.