### PR TITLE
Configure logging in non-nested method

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionEndpoint.cs
@@ -46,11 +46,9 @@
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
-            var functionExecutionContext = new FunctionExecutionContext(executionContext, functionsLogger);
-
             try
             {
-                await InitializeEndpointIfNecessary(functionExecutionContext, CancellationToken.None)
+                await InitializeEndpointIfNecessary(executionContext, functionsLogger, CancellationToken.None)
                     .ConfigureAwait(false);
 
                 await Process(message, new MessageReceiverTransactionStrategy(message, messageReceiver), pipeline)
@@ -80,9 +78,7 @@
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
-            var functionExecutionContext = new FunctionExecutionContext(executionContext, functionsLogger);
-
-            await InitializeEndpointIfNecessary(functionExecutionContext, CancellationToken.None)
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger, CancellationToken.None)
                 .ConfigureAwait(false);
 
             await Process(message, NoTransactionStrategy.Instance, pipeline)
@@ -144,12 +140,7 @@
                     new ContextBag());
         }
 
-        /// <summary>
-        /// Allows to forcefully initialize the endpoint if it hasn't been initialized yet.
-        /// </summary>
-        /// <param name="executionContext">The execution context.</param>
-        /// <param name="token">The cancellation token or default cancellation token.</param>
-        async Task InitializeEndpointIfNecessary(FunctionExecutionContext executionContext, CancellationToken token = default)
+        async Task InitializeEndpointIfNecessary(ExecutionContext executionContext, ILogger logger, CancellationToken token = default)
         {
             if (pipeline == null)
             {
@@ -158,7 +149,8 @@
                 {
                     if (pipeline == null)
                     {
-                        endpoint = await endpointFactory(executionContext).ConfigureAwait(false);
+                        var functionExecutionContext = new FunctionExecutionContext(executionContext, logger);
+                        endpoint = await endpointFactory(functionExecutionContext).ConfigureAwait(false);
 
                         pipeline = configuration.PipelineInvoker;
                     }
@@ -173,8 +165,9 @@
         /// <inheritdoc />
         public async Task Send(object message, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
             await endpoint.Send(message, options).ConfigureAwait(false);
         }
 
@@ -187,8 +180,9 @@
         /// <inheritdoc />
         public async Task Send<T>(Action<T> messageConstructor, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
             await endpoint.Send(messageConstructor, options).ConfigureAwait(false);
         }
 
@@ -201,75 +195,54 @@
         /// <inheritdoc />
         public async Task Publish(object message, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
             await endpoint.Publish(message, options).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
         public async Task Publish<T>(Action<T> messageConstructor, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
             await endpoint.Publish(messageConstructor, options).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task Publish(object message, ExecutionContext executionContext, ILogger functionsLogger = null)
-        {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
-
-            await endpoint.Publish(message).ConfigureAwait(false);
-        }
+        public Task Publish(object message, ExecutionContext executionContext, ILogger functionsLogger = null) =>
+            Publish(message, new PublishOptions(), executionContext, functionsLogger);
 
         /// <inheritdoc />
-        public async Task Publish<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null)
-        {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
-
-            await endpoint.Publish(messageConstructor).ConfigureAwait(false);
-        }
+        public Task Publish<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null) =>
+            Publish(messageConstructor, new PublishOptions(), executionContext, functionsLogger);
 
         /// <inheritdoc />
         public async Task Subscribe(Type eventType, SubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
             await endpoint.Subscribe(eventType, options).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task Subscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null)
-        {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
-
-            await endpoint.Subscribe(eventType).ConfigureAwait(false);
-        }
+        public Task Subscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null) =>
+            Subscribe(eventType, new SubscribeOptions(), executionContext, functionsLogger);
 
         /// <inheritdoc />
         public async Task Unsubscribe(Type eventType, UnsubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null)
         {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
+            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
+            await InitializeEndpointIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
             await endpoint.Unsubscribe(eventType, options).ConfigureAwait(false);
         }
 
         /// <inheritdoc />
-        public async Task Unsubscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null)
-        {
-            await InitializeEndpointUsedOutsideHandlerIfNecessary(executionContext, functionsLogger).ConfigureAwait(false);
-
-            await endpoint.Unsubscribe(eventType).ConfigureAwait(false);
-        }
-
-        async Task InitializeEndpointUsedOutsideHandlerIfNecessary(ExecutionContext executionContext, ILogger functionsLogger)
-        {
-            FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
-
-            var functionExecutionContext = new FunctionExecutionContext(executionContext, functionsLogger);
-
-            await InitializeEndpointIfNecessary(functionExecutionContext).ConfigureAwait(false);
-        }
+        public Task Unsubscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null) =>
+            Unsubscribe(eventType, new UnsubscribeOptions(), executionContext, functionsLogger);
 
         internal static void LoadAssemblies(string assemblyDirectory)
         {


### PR DESCRIPTION
Fixes #292

Configuring the logger in a nested method causes the internally used `AsyncLocal` to lose the assigned logger upon returning. This causes the actual logger used for message operations to be `null` and log entries to be added to the buffer, causing them to be only flushed on the next incoming message or message operation.