### PR TITLE
Core update

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBus.AzureFunctions.InProcess.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBus.AzureFunctions.InProcess.ServiceBus.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.3.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="3.0.0-alpha.155" />
+    <!-- This minim version of the NSB alpha is required for System.Security.Cryptography.XML compatibility. Can be removed when switching to RTM packages -->
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="2.0.0-alpha.624" />
     <PackageReference Include="NServiceBus.Extensions.DependencyInjection" Version="2.0.0-alpha.140" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.1" PrivateAssets="All" />

--- a/src/ServiceBus.AcceptanceTests/ServiceBus.AcceptanceTests.csproj
+++ b/src/ServiceBus.AcceptanceTests/ServiceBus.AcceptanceTests.csproj
@@ -14,8 +14,8 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
-    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
+    <PackageReference Include="NServiceBus.AcceptanceTesting" Version="8.0.0-alpha.1898" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>

--- a/src/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/src/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -15,7 +15,7 @@
   <ItemGroup>
     <PackageReference Include="GitHubActionsTestLogger" Version="1.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
     <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
   </ItemGroup>

--- a/src/Testing.Handlers/Testing.Handlers.csproj
+++ b/src/Testing.Handlers/Testing.Handlers.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1897" />
+    <PackageReference Include="NServiceBus" Version="8.0.0-alpha.1898" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Updates to latest core alpha to resolve incompatibility issues with `System.Security.Cryptography.XML` as this newer version of core downgraded the package dependency from 5.0 to 4.7.

I've added an explicit reference to the package for now as otherwise NSB is only referenced as a transitive dependency from the transport/JSON packages which have a lower minimum dependency (and therefore it would resolve to an older alpha version of core v8). This explicit reference can be removed when we switch to RTM packages.