### PR TITLE
Disable GitVersion repository normalization 

### DIFF
--- a/src/Custom.Build.props
+++ b/src/Custom.Build.props
@@ -2,6 +2,10 @@
 
   <PropertyGroup>
     <ParticularAnalyzersVersion>0.9.0</ParticularAnalyzersVersion>
+
+    <!-- Disable GitVersion normalization for build agents to generate correct versions from tags -->
+    <!-- See https://github.com/GitTools/GitVersion/issues/2838 for further details -->
+    <GitVersion_NoNormalizeEnabled>true</GitVersion_NoNormalizeEnabled>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
To generate the correct nuget package versions for the tagged release.