### PR TITLE
Separate message processing  from interface used to send message

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -90,6 +90,7 @@
             functionsHostBuilder.Services.AddSingleton(serviceBusTriggeredEndpointConfiguration);
             functionsHostBuilder.Services.AddSingleton(startableEndpoint);
             functionsHostBuilder.Services.AddSingleton<IFunctionEndpoint, InProcessFunctionEndpoint>();
+            functionsHostBuilder.Services.AddSingleton<IMessageProcessor, InProcessFunctionEndpoint>();
         }
 
         internal static IStartableEndpointWithExternallyManagedContainer Configure(

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/IFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/IFunctionEndpoint.cs
@@ -3,22 +3,14 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.ServiceBus;
-    using Microsoft.Azure.ServiceBus.Core;
     using Microsoft.Extensions.Logging;
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
 
     /// <summary>
-    /// An NServiceBus endpoint hosted in Azure Function which does not receive messages automatically but only handles
-    /// messages explicitly passed to it by the caller.
+    /// Allows NServiceBus messages to be emitted by functions.
     /// </summary>
     public interface IFunctionEndpoint
     {
-        /// <summary>
-        /// Processes a message received from an AzureServiceBus trigger using the NServiceBus message pipeline.
-        /// </summary>
-        Task Process(Message message, ExecutionContext executionContext, IMessageReceiver messageReceiver, bool enableCrossEntityTransactions, ILogger functionsLogger = null, CancellationToken cancellationToken = default);
-
         /// <summary>
         /// Sends the provided message.
         /// </summary>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/IMessageProcessor.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/IMessageProcessor.cs
@@ -1,0 +1,20 @@
+﻿namespace NServiceBus
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.ServiceBus;
+    using Microsoft.Azure.ServiceBus.Core;
+    using Microsoft.Extensions.Logging;
+    using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
+
+    /// <summary>
+    /// Allows Azure ServiceBus messages to be processed by the NServiceBus endpoint.
+    /// </summary>
+    public interface IMessageProcessor
+    {
+        /// <summary>
+        /// Processes a message received from an AzureServiceBus trigger using the NServiceBus message pipeline.
+        /// </summary>
+        Task Process(Message message, ExecutionContext executionContext, IMessageReceiver messageReceiver, bool enableCrossEntityTransactions, ILogger functionsLogger = null, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -11,7 +11,7 @@
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
     using IMessageReceiver = Microsoft.Azure.ServiceBus.Core.IMessageReceiver;
 
-    class InProcessFunctionEndpoint : IFunctionEndpoint
+    class InProcessFunctionEndpoint : IFunctionEndpoint, IMessageProcessor
     {
         public InProcessFunctionEndpoint(
             IStartableEndpointWithExternallyManagedContainer externallyManagedContainerEndpoint,

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/obsoletes-v3.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/obsoletes-v3.cs
@@ -13,7 +13,7 @@ namespace NServiceBus
 
 namespace NServiceBus
 {
-    [ObsoleteEx(ReplacementTypeOrMember = nameof(IFunctionEndpoint),
+    [ObsoleteEx(ReplacementTypeOrMember = nameof(IMessageProcessor),
                   TreatAsErrorFromVersion = "3",
                   RemoveInVersion = "4")]
     public class FunctionEndpoint

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Can_enable_transactions.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Can_enable_transactions.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("NServiceBusFunctionEndpointTrigger-endpoint")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, true, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, true, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Can_override_trigger_function_name.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Can_override_trigger_function_name.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("trigger")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.NameIsStringValue.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.NameIsStringValue.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("NServiceBusFunctionEndpointTrigger-endpoint")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Two_optionals_out_of_order.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Two_optionals_out_of_order.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("trigger")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, true, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, true, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Use_two_optionals.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.Use_two_optionals.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("trigger")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, true, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, true, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingFullyQualifiedAttributeName.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingFullyQualifiedAttributeName.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("NServiceBusFunctionEndpointTrigger-endpoint")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingNamespace.approved.txt
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/ApprovalFiles/SourceGeneratorApprovals.UsingNamespace.approved.txt
@@ -10,11 +10,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {
-        this.endpoint = endpoint;
+        this.processor = processor;
     }
 
     [FunctionName("NServiceBusFunctionEndpointTrigger-endpoint")]
@@ -26,6 +26,6 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {
-        await endpoint.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, false, logger,cancellationToken);
     }
 }

--- a/src/NServiceBus.AzureFunctions.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator/TriggerFunctionGenerator.cs
@@ -118,11 +118,11 @@ using NServiceBus;
 
 class FunctionEndpointTrigger
 {{
-    readonly IFunctionEndpoint endpoint;
+    readonly IMessageProcessor processor;
 
-    public FunctionEndpointTrigger(IFunctionEndpoint endpoint)
+    public FunctionEndpointTrigger(IMessageProcessor processor)
     {{
-        this.endpoint = endpoint;
+        this.processor = processor;
     }}
 
     [FunctionName(""{syntaxReceiver.triggerFunctionName}"")]
@@ -134,7 +134,7 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {{
-        await endpoint.Process(message, executionContext, messageReceiver, {syntaxReceiver.enableCrossEntityTransactions.ToString().ToLowerInvariant()}, logger,cancellationToken);
+        await processor.Process(message, executionContext, messageReceiver, {syntaxReceiver.enableCrossEntityTransactions.ToString().ToLowerInvariant()}, logger,cancellationToken);
     }}
 }}";
             context.AddSource("NServiceBus__FunctionEndpointTrigger", SourceText.From(source, Encoding.UTF8));

--- a/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
@@ -122,7 +122,7 @@
             readonly ScenarioContext scenarioContext;
             readonly Type functionComponentType;
             IList<object> messages;
-            IFunctionEndpoint endpoint;
+            IMessageProcessor endpoint;
         }
     }
 }

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -2,7 +2,7 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"ServiceBus.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 namespace NServiceBus
 {
-    [System.Obsolete("Use `IFunctionEndpoint` instead. Will be removed in version 4.0.0.", true)]
+    [System.Obsolete("Use `IMessageProcessor` instead. Will be removed in version 4.0.0.", true)]
     public class FunctionEndpoint
     {
         public FunctionEndpoint() { }
@@ -22,7 +22,6 @@ namespace NServiceBus
     }
     public interface IFunctionEndpoint
     {
-        System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Azure.ServiceBus.Core.IMessageReceiver messageReceiver, bool enableCrossEntityTransactions, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Publish(object message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Publish(object message, NServiceBus.PublishOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Publish<T>(System.Action<T> messageConstructor, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
@@ -35,6 +34,10 @@ namespace NServiceBus
         System.Threading.Tasks.Task Subscribe(System.Type eventType, NServiceBus.SubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Unsubscribe(System.Type eventType, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
+    }
+    public interface IMessageProcessor
+    {
+        System.Threading.Tasks.Task Process(Microsoft.Azure.ServiceBus.Message message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Azure.ServiceBus.Core.IMessageReceiver messageReceiver, bool enableCrossEntityTransactions, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
     }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.All)]
     public sealed class NServiceBusTriggerFunctionAttribute : System.Attribute


### PR DESCRIPTION
This separates the part users should care about from the processing part which should only be used when having to work around bugs in our source generator.

This makes https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/issues/358 easier as well since we don't have to provide a way to test the processing part.
