### PR TITLE
[Spike] Less strongly typed public api that is less prone to versioning issues

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/IFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/IFunctionEndpoint.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Threading;
     using System.Threading.Tasks;
-    using Azure.Messaging.ServiceBus;
-    using Microsoft.Azure.WebJobs.ServiceBus;
     using Microsoft.Extensions.Logging;
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
 
@@ -14,26 +12,6 @@
     /// </summary>
     public interface IFunctionEndpoint
     {
-        /// <summary>
-        /// Processes the received message in atomic sends with receive mode.
-        /// </summary>
-        Task ProcessAtomic(
-           ServiceBusReceivedMessage message,
-           ExecutionContext executionContext,
-           ServiceBusClient serviceBusClient,
-           ServiceBusMessageActions messageActions,
-           ILogger functionsLogger = null,
-           CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Processes the received message in receive only transaction mode.
-        /// </summary>
-        Task ProcessNonAtomic(
-            ServiceBusReceivedMessage message,
-            ExecutionContext executionContext,
-            ILogger functionsLogger = null,
-            CancellationToken cancellationToken = default);
-
         /// <summary>
         /// Sends the provided message.
         /// </summary>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -12,9 +12,12 @@
     using Transport;
     using ExecutionContext = Microsoft.Azure.WebJobs.ExecutionContext;
 
-    class InProcessFunctionEndpoint : IFunctionEndpoint
+    /// <summary>
+    /// TODO
+    /// </summary>
+    public class InProcessFunctionEndpoint : IFunctionEndpoint
     {
-        public InProcessFunctionEndpoint(
+        internal InProcessFunctionEndpoint(
             IStartableEndpointWithExternallyManagedContainer externallyManagedContainerEndpoint,
             ServiceBusTriggeredEndpointConfiguration configuration,
             IServiceProvider serviceProvider)
@@ -23,7 +26,7 @@
             endpointFactory = _ => externallyManagedContainerEndpoint.Start(serviceProvider);
         }
 
-        public async Task Send(object message, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        async Task IFunctionEndpoint.Send(object message, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -31,12 +34,12 @@
             await endpoint.Send(message, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Send(object message, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        Task IFunctionEndpoint.Send(object message, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
-            return Send(message, new SendOptions(), executionContext, functionsLogger, cancellationToken);
+            return ((IFunctionEndpoint)this).Send(message, new SendOptions(), executionContext, functionsLogger, cancellationToken);
         }
 
-        public async Task Send<T>(Action<T> messageConstructor, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        async Task IFunctionEndpoint.Send<T>(Action<T> messageConstructor, SendOptions options, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -44,12 +47,12 @@
             await endpoint.Send(messageConstructor, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Send<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        Task IFunctionEndpoint.Send<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
-            return Send(messageConstructor, new SendOptions(), executionContext, functionsLogger, cancellationToken);
+            return ((IFunctionEndpoint)this).Send(messageConstructor, new SendOptions(), executionContext, functionsLogger, cancellationToken);
         }
 
-        public async Task Publish(object message, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        async Task IFunctionEndpoint.Publish(object message, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -57,12 +60,12 @@
             await endpoint.Publish(message, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Publish(object message, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        Task IFunctionEndpoint.Publish(object message, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
-            return Publish(message, new PublishOptions(), executionContext, functionsLogger, cancellationToken);
+            return ((IFunctionEndpoint)this).Publish(message, new PublishOptions(), executionContext, functionsLogger, cancellationToken);
         }
 
-        public async Task Publish<T>(Action<T> messageConstructor, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        async Task IFunctionEndpoint.Publish<T>(Action<T> messageConstructor, PublishOptions options, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -70,12 +73,12 @@
             await endpoint.Publish(messageConstructor, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Publish<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        Task IFunctionEndpoint.Publish<T>(Action<T> messageConstructor, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
-            return Publish(messageConstructor, new PublishOptions(), executionContext, functionsLogger, cancellationToken);
+            return ((IFunctionEndpoint)this).Publish(messageConstructor, new PublishOptions(), executionContext, functionsLogger, cancellationToken);
         }
 
-        public async Task Subscribe(Type eventType, SubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        async Task IFunctionEndpoint.Subscribe(Type eventType, SubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -83,12 +86,12 @@
             await endpoint.Subscribe(eventType, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Subscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        Task IFunctionEndpoint.Subscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
-            return Subscribe(eventType, new SubscribeOptions(), executionContext, functionsLogger, cancellationToken);
+            return ((IFunctionEndpoint)this).Subscribe(eventType, new SubscribeOptions(), executionContext, functionsLogger, cancellationToken);
         }
 
-        public async Task Unsubscribe(Type eventType, UnsubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        async Task IFunctionEndpoint.Unsubscribe(Type eventType, UnsubscribeOptions options, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -96,16 +99,34 @@
             await endpoint.Unsubscribe(eventType, options, cancellationToken).ConfigureAwait(false);
         }
 
-        public Task Unsubscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger = null, CancellationToken cancellationToken = default)
+        Task IFunctionEndpoint.Unsubscribe(Type eventType, ExecutionContext executionContext, ILogger functionsLogger, CancellationToken cancellationToken)
         {
-            return Unsubscribe(eventType, new UnsubscribeOptions(), executionContext, functionsLogger, cancellationToken);
+            return ((IFunctionEndpoint)this).Unsubscribe(eventType, new UnsubscribeOptions(), executionContext, functionsLogger, cancellationToken);
         }
 
-        public async Task ProcessNonAtomic(
+
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="executionContext"></param>
+        /// <param name="functionsLogger"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task ProcessNonAtomic(
+            object message,
+            object executionContext,
+            object functionsLogger = null,
+            CancellationToken cancellationToken = default)
+        {
+            return ProcessNonAtomic((ServiceBusReceivedMessage)message, (ExecutionContext)executionContext, (ILogger)functionsLogger, cancellationToken);
+        }
+
+        async Task ProcessNonAtomic(
             ServiceBusReceivedMessage message,
             ExecutionContext executionContext,
-            ILogger functionsLogger = null,
-            CancellationToken cancellationToken = default)
+            ILogger functionsLogger,
+            CancellationToken cancellationToken)
         {
             FunctionsLoggerFactory.Instance.SetCurrentLogger(functionsLogger);
 
@@ -133,7 +154,28 @@
             }
         }
 
-        public async Task ProcessAtomic(
+        /// <summary>
+        /// TODO
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="executionContext"></param>
+        /// <param name="serviceBusClient"></param>
+        /// <param name="messageActions"></param>
+        /// <param name="functionsLogger"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public Task ProcessAtomic(
+            object message,
+            object executionContext,
+            object serviceBusClient,
+            object messageActions,
+            object functionsLogger = null,
+            CancellationToken cancellationToken = default)
+        {
+            return ProcessAtomic((ServiceBusReceivedMessage)message, (ExecutionContext)executionContext, (ServiceBusClient)serviceBusClient, (ServiceBusMessageActions)messageActions, (ILogger)functionsLogger, cancellationToken);
+        }
+
+        async Task ProcessAtomic(
             ServiceBusReceivedMessage message,
             ExecutionContext executionContext,
             ServiceBusClient serviceBusClient,

--- a/src/NServiceBus.AzureFunctions.SourceGenerator/TriggerFunctionGenerator.cs
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator/TriggerFunctionGenerator.cs
@@ -145,7 +145,7 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {{
-        return endpoint.ProcessAtomic(message, executionContext, client, messageActions, logger, cancellationToken);
+        return ((InProcessFunctionEndpoint)endpoint).ProcessAtomic(message, executionContext, client, messageActions, logger, cancellationToken);
     }}
 }}";
         }
@@ -179,7 +179,7 @@ class FunctionEndpointTrigger
         ExecutionContext executionContext,
         CancellationToken cancellationToken)
     {{
-        return endpoint.ProcessNonAtomic(message, executionContext, logger, cancellationToken);
+        return ((InProcessFunctionEndpoint)endpoint).ProcessNonAtomic(message, executionContext, logger, cancellationToken);
     }}
 }}";
         }

--- a/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
@@ -198,7 +198,7 @@
             }
 
             IList<object> messages;
-            IFunctionEndpoint endpoint;
+            InProcessFunctionEndpoint endpoint;
 
             readonly Action<ServiceBusTriggeredEndpointConfiguration> configurationCustomization;
             readonly ScenarioContext scenarioContext;

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -32,6 +32,11 @@ namespace NServiceBus
         System.Threading.Tasks.Task Unsubscribe(System.Type eventType, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
         System.Threading.Tasks.Task Unsubscribe(System.Type eventType, NServiceBus.UnsubscribeOptions options, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default);
     }
+    public class InProcessFunctionEndpoint : NServiceBus.IFunctionEndpoint
+    {
+        public System.Threading.Tasks.Task ProcessAtomic(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Azure.Messaging.ServiceBus.ServiceBusClient serviceBusClient, Microsoft.Azure.WebJobs.ServiceBus.ServiceBusMessageActions messageActions, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default) { }
+        public System.Threading.Tasks.Task ProcessNonAtomic(Azure.Messaging.ServiceBus.ServiceBusReceivedMessage message, Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger functionsLogger = null, System.Threading.CancellationToken cancellationToken = default) { }
+    }
     [System.AttributeUsage(System.AttributeTargets.Assembly | System.AttributeTargets.All)]
     public sealed class NServiceBusTriggerFunctionAttribute : System.Attribute
     {


### PR DESCRIPTION
This is based on @bording idea to rely on our sourcegenerator to hide the "ugly" API from our customers. This has the upside of:

- Doesn't have to change when MS changes SDK types
- Doesn't use an interface which means less risk to break

As an aside, this achieves interface segregation where users would continue to use `IFunctionEndpoint` to perform their message operations outside the message handling pipeline just like today without having to see the process method which they shouldn't be using.

The only negative effect is that customers that DO have to use the workaround to call the process methods manually would have less type safety but that is a small price to pay and we should strive to evolve our source generator to cater for their needs anyway to minimize the need to use the workaround.