### PR TITLE
Validate that EnableCrossEntityTransactions is configured when SendsAtomicWithReceive is enabled

### DIFF
--- a/src/ManualTests.HostV4/SomeEvent.cs
+++ b/src/ManualTests.HostV4/SomeEvent.cs
@@ -1,0 +1,8 @@
+﻿using NServiceBus;
+
+public class SomeEvent : IEvent
+{
+    public SomeEvent()
+    {
+    }
+}

--- a/src/ManualTests.HostV4/SomeEventMessageHandler.cs
+++ b/src/ManualTests.HostV4/SomeEventMessageHandler.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+using NServiceBus;
+using NServiceBus.Logging;
+
+public class SomeEventMessageHandler : IHandleMessages<SomeEvent>
+{
+    static readonly ILog Log = LogManager.GetLogger<SomeEventMessageHandler>();
+
+    public Task Handle(SomeEvent message, IMessageHandlerContext context)
+    {
+        Log.Warn($"Handling {nameof(SomeEvent)} in {nameof(SomeEventMessageHandler)}");
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/ManualTests.HostV4/Startup.cs
+++ b/src/ManualTests.HostV4/Startup.cs
@@ -3,7 +3,6 @@ using NServiceBus;
 
 [assembly: FunctionsStartup(typeof(Startup))]
 [assembly: NServiceBusTriggerFunction("InProcess-HostV4", SendsAtomicWithReceive = true)]
-
 public class Startup : FunctionsStartup
 {
     public override void Configure(IFunctionsHostBuilder builder)

--- a/src/ManualTests.HostV4/TriggerMessageHandler.cs
+++ b/src/ManualTests.HostV4/TriggerMessageHandler.cs
@@ -6,10 +6,11 @@ public class TriggerMessageHandler : IHandleMessages<TriggerMessage>
 {
     static readonly ILog Log = LogManager.GetLogger<TriggerMessageHandler>();
 
-    public Task Handle(TriggerMessage message, IMessageHandlerContext context)
+    public async Task Handle(TriggerMessage message, IMessageHandlerContext context)
     {
         Log.Warn($"Handling {nameof(TriggerMessage)} in {nameof(TriggerMessageHandler)}");
 
-        return context.SendLocal(new SomeOtherMessage());
+        await context.SendLocal(new SomeOtherMessage()).ConfigureAwait(false);
+        await context.Publish(new SomeEvent()).ConfigureAwait(false);
     }
 }

--- a/src/ManualTests.HostV4/host.json
+++ b/src/ManualTests.HostV4/host.json
@@ -1,7 +1,7 @@
 {
   "version": "2.0",
   "extensions": {
-    "serviceBus": {
+    "ServiceBus": {
       "EnableCrossEntityTransactions": true
     }
   }

--- a/src/ManualTests.HostV4/host.json
+++ b/src/ManualTests.HostV4/host.json
@@ -1,3 +1,8 @@
 {
-  "version": "2.0"
+  "version": "2.0",
+  "extensions": {
+    "ServiceBus": {
+      "EnableCrossEntityTransactions": true
+    }
+  }
 }

--- a/src/ManualTests.HostV4/host.json
+++ b/src/ManualTests.HostV4/host.json
@@ -1,8 +1,3 @@
 {
-  "version": "2.0",
-  "extensions": {
-    "ServiceBus": {
-      "EnableCrossEntityTransactions": true
-    }
-  }
+  "version": "2.0"
 }

--- a/src/ManualTests.HostV4/host.json
+++ b/src/ManualTests.HostV4/host.json
@@ -1,3 +1,8 @@
 {
-    "version": "2.0"
+  "version": "2.0",
+  "extensions": {
+    "serviceBus": {
+      "EnableCrossEntityTransactions": true
+    }
+  }
 }

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/ServiceBusTriggeredEndpointConfiguration.cs
@@ -80,7 +80,7 @@
                 var serviceBusOptions = configuration.GetSection("AzureFunctionsJobHost:extensions:ServiceBus")
                     .Get<ServiceBusOptions>();
 
-                if (!serviceBusOptions.EnableCrossEntityTransactions)
+                if (serviceBusOptions == null || serviceBusOptions.EnableCrossEntityTransactions)
                 {
                     throw new Exception("SendsAtomicWithReceive mode requires EnableCrossEntityTransactions needs to be enabled on the ServiceBusOptions.");
                 }

--- a/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
@@ -83,7 +83,7 @@
 
             public override Task Start(CancellationToken token)
             {
-                var functionEndpointConfiguration = new ServiceBusTriggeredEndpointConfiguration(Name, default, null);
+                var functionEndpointConfiguration = new ServiceBusTriggeredEndpointConfiguration(Name, default, TransportTransactionMode.ReceiveOnly);
                 configurationCustomization(functionEndpointConfiguration);
                 var endpointConfiguration = functionEndpointConfiguration.AdvancedConfiguration;
 

--- a/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
+++ b/src/ServiceBus.Tests/When_no_connection_string_is_provided.cs
@@ -18,7 +18,7 @@
                 Environment.SetEnvironmentVariable(defaultConnectionStringKey, null, EnvironmentVariableTarget.Process);
 
                 var exception = Assert.Throws<Exception>(
-                    () => new ServiceBusTriggeredEndpointConfiguration("SampleEndpoint", default, null),
+                    () => new ServiceBusTriggeredEndpointConfiguration("SampleEndpoint", default, TransportTransactionMode.ReceiveOnly),
                     "Exception should be thrown at endpoint creation so that the error will be found during functions startup"
                 );
 

--- a/src/ServiceBus.Tests/When_shipping_handlers_in_dedicated_assembly.cs
+++ b/src/ServiceBus.Tests/When_shipping_handlers_in_dedicated_assembly.cs
@@ -24,7 +24,7 @@
 
             var serviceCollection = new ServiceCollection();
 
-            var configuration = new ServiceBusTriggeredEndpointConfiguration("assemblyTest", default, null);
+            var configuration = new ServiceBusTriggeredEndpointConfiguration("assemblyTest", default, TransportTransactionMode.ReceiveOnly);
             configuration.UseSerialization<XmlSerializer>();
 
             var endpointConfiguration = configuration.AdvancedConfiguration;


### PR DESCRIPTION
This makes sure that the ServiceBusClient is configured correctly to support cross entity transactions.

Note that this will only catch issues when our attribute is used (which should be most of the use cases. We could add a runtime check that validates on first invocation but I'm not sure its worth it?