### PR TITLE
Host throws assembly scanning errors on startup

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -239,7 +239,9 @@
             "Grpc.Net.ClientFactory.dll",
             "Azure.Identity.dll",
             "Microsoft.Extensions.Azure.dll",
-            "NServiceBus.Extensions.DependencyInjection.dll"
+            "NServiceBus.Extensions.DependencyInjection.dll",
+            "Microsoft.Identity.Client.dll",
+            "Microsoft.Identity.Client.Extensions.Msal.dll"
         };
 
         internal async Task InitializeEndpointIfNecessary(ExecutionContext executionContext, ILogger logger, CancellationToken cancellationToken)

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -241,7 +241,9 @@
             "Microsoft.Extensions.Azure.dll",
             "NServiceBus.Extensions.DependencyInjection.dll",
             "Microsoft.Identity.Client.dll",
-            "Microsoft.Identity.Client.Extensions.Msal.dll"
+            "Microsoft.Identity.Client.Extensions.Msal.dll",
+            "Azure.Storage.Common.dll",
+            "Azure.Storage.Blobs.dll"
         };
 
         internal async Task InitializeEndpointIfNecessary(ExecutionContext executionContext, ILogger logger, CancellationToken cancellationToken)


### PR DESCRIPTION
This fixes the bug but we should make sure we can repro with a unit test before merging this.


https://microsoft.github.io/AzureTipsAndTricks/blog/tip196.html and https://stackoverflow.com/questions/59743560/how-to-unit-test-azure-functions-in-visual-studio show how to use func.exe but there might be other better ways