### PR TITLE
Defer serverless set up until after customization applied

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionsHostBuilderExtensions.cs
@@ -81,6 +81,7 @@
         static void RegisterEndpointFactory(IFunctionsHostBuilder functionsHostBuilder,
             ServiceBusTriggeredEndpointConfiguration serviceBusTriggeredEndpointConfiguration)
         {
+            var serverless = serviceBusTriggeredEndpointConfiguration.MakeServerless();
             // When using functions, assemblies are moved to a 'bin' folder within FunctionsHostBuilderContext.ApplicationRootPath.
             var startableEndpoint = Configure(
                 serviceBusTriggeredEndpointConfiguration.AdvancedConfiguration,
@@ -89,6 +90,7 @@
 
             functionsHostBuilder.Services.AddSingleton(serviceBusTriggeredEndpointConfiguration);
             functionsHostBuilder.Services.AddSingleton(startableEndpoint);
+            functionsHostBuilder.Services.AddSingleton(serverless);
             functionsHostBuilder.Services.AddSingleton<IFunctionEndpoint, InProcessFunctionEndpoint>();
         }
 

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -18,10 +18,10 @@
     {
         public InProcessFunctionEndpoint(
             IStartableEndpointWithExternallyManagedContainer externallyManagedContainerEndpoint,
-            ServiceBusTriggeredEndpointConfiguration configuration,
+            ServerlessInterceptor serverlessInterceptor,
             IServiceProvider serviceProvider)
         {
-            this.configuration = configuration;
+            this.serverlessInterceptor = serverlessInterceptor;
             endpointFactory = _ => externallyManagedContainerEndpoint.Start(serviceProvider);
         }
 
@@ -262,7 +262,7 @@
                         var functionExecutionContext = new FunctionExecutionContext(executionContext, logger);
                         endpoint = await endpointFactory(functionExecutionContext).ConfigureAwait(false);
 
-                        pipeline = configuration.PipelineInvoker;
+                        pipeline = serverlessInterceptor.PipelineInvoker;
                     }
                 }
                 finally
@@ -277,6 +277,6 @@
 
         readonly Func<FunctionExecutionContext, Task<IEndpointInstance>> endpointFactory;
         readonly SemaphoreSlim semaphoreLock = new SemaphoreSlim(initialCount: 1, maxCount: 1);
-        readonly ServiceBusTriggeredEndpointConfiguration configuration;
+        readonly ServerlessInterceptor serverlessInterceptor;
     }
 }

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/Serverless/ServerlessInterceptor.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/Serverless/ServerlessInterceptor.cs
@@ -1,0 +1,11 @@
+﻿namespace NServiceBus.AzureFunctions.InProcess.ServiceBus.Serverless
+{
+    class ServerlessInterceptor
+    {
+        readonly ServerlessTransport transport;
+
+        public ServerlessInterceptor(ServerlessTransport transport) => this.transport = transport;
+
+        public PipelineInvoker PipelineInvoker => transport.PipelineInvoker;
+    }
+}

--- a/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
+++ b/src/ServiceBus.AcceptanceTests/FunctionEndpointComponent.cs
@@ -108,6 +108,7 @@
                         }));
 
                 configurationCustomization(functionEndpointConfiguration);
+                var serverless = functionEndpointConfiguration.MakeServerless();
 
                 endpointConfiguration.RegisterComponents(c => c.AddSingleton(scenarioContext.GetType(), scenarioContext));
 
@@ -117,7 +118,7 @@
                 var startableEndpointWithExternallyManagedContainer = EndpointWithExternallyManagedContainer.Create(endpointConfiguration, serviceCollection);
                 var serviceProvider = serviceCollection.BuildServiceProvider();
 
-                endpoint = new InProcessFunctionEndpoint(startableEndpointWithExternallyManagedContainer, functionEndpointConfiguration, serviceProvider);
+                endpoint = new InProcessFunctionEndpoint(startableEndpointWithExternallyManagedContainer, serverless, serviceProvider);
 
                 return Task.CompletedTask;
             }

--- a/src/ServiceBus.Tests/When_shipping_handlers_in_dedicated_assembly.cs
+++ b/src/ServiceBus.Tests/When_shipping_handlers_in_dedicated_assembly.cs
@@ -31,6 +31,7 @@
             endpointConfiguration.UsePersistence<LearningPersistence>();
             endpointConfiguration.EnableInstallers();
             var settings = endpointConfiguration.GetSettings();
+            var serverless = configuration.MakeServerless();
 
             var startableEndpoint = FunctionsHostBuilderExtensions.Configure(
                 configuration.AdvancedConfiguration,
@@ -38,7 +39,7 @@
                 Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ExternalHandlers"));
 
             var serviceProvider = serviceCollection.BuildServiceProvider();
-            var endpoint = new InProcessFunctionEndpoint(startableEndpoint, configuration, serviceProvider);
+            var endpoint = new InProcessFunctionEndpoint(startableEndpoint, serverless, serviceProvider);
 
             // we need to process an actual message to have the endpoint being created
             await endpoint.InitializeEndpointIfNecessary(new Microsoft.Azure.WebJobs.ExecutionContext(), null, CancellationToken.None);


### PR DESCRIPTION
This is the in process equivalent of https://github.com/Particular/NServiceBus.AzureFunctions.Worker.ServiceBus/pull/255

Defers setting up the serverless infrastructure until after the user customization has been applied. After this change, it doesn't matter if `UseTransport(..)` is called, as that configuration is overwritten just before the endpoint is started.