### PR TITLE
Exclude Azure.Security.KeyVault.Secrets from scanning

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -247,7 +247,8 @@
             "Microsoft.Identity.Client.dll",
             "Microsoft.Identity.Client.Extensions.Msal.dll",
             "Azure.Storage.Common.dll",
-            "Azure.Storage.Blobs.dll"
+            "Azure.Storage.Blobs.dll",
+            "Azure.Security.KeyVault.Secrets.dll"
         };
 
         internal async Task InitializeEndpointIfNecessary(ExecutionContext executionContext, ILogger logger, CancellationToken cancellationToken)


### PR DESCRIPTION
To avoid 

```
"System.Exception: 'Could not load '[C:\Users\XXXX\AppData\Local\AzureFunctionsTools\Releases\4.35.0\cli_x64\Azure.Security.KeyVault.Secrets.dll'.](file:///C:/Users/XXXX/AppData/Local/AzureFunctionsTools/Releases/4.35.0/cli_x64/Azure.Security.KeyVault.Secrets.dll'.) Consider excluding that assembly from the scanning.'"
```