### PR TITLE
Move FunctionsPreservedDependencies to props file to embed in package

### DIFF
--- a/src/IntegrationTests.HostV4/IntegrationTests.HostV4.csproj
+++ b/src/IntegrationTests.HostV4/IntegrationTests.HostV4.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -26,15 +26,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- Prevent Functions from removing NServiceBus dependencies that it thinks are included "in the box" -->
-    <FunctionsPreservedDependencies Include="System.Diagnostics.DiagnosticSource.dll" />
-    <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
-    <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Update="host.json" CopyToOutputDirectory="PreserveNewest" />
     <None Update="local.settings.json" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="Never" />
   </ItemGroup>
+
+  <!-- Import the props file from the component because it's referenced as a ProjectReference here, not a PackageReference -->
+  <Import Project="..\NServiceBus.AzureFunctions.InProcess.ServiceBus\build\NServiceBus.AzureFunctions.InProcess.ServiceBus.props" />
 
 </Project>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBus.AzureFunctions.InProcess.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBus.AzureFunctions.InProcess.ServiceBus.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.11.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.1.1, 9.0.0)" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[3.0.0, 4.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
@@ -2,4 +2,10 @@
 	<PropertyGroup>
 		<WarningsAsErrors>CS8032</WarningsAsErrors>
 	</PropertyGroup>
+  <ItemGroup>
+    <!-- Prevent Functions from removing NServiceBus dependencies that it thinks are included "in the box" -->
+    <FunctionsPreservedDependencies Include="System.Diagnostics.DiagnosticSource.dll" />
+    <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
+    <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
In order to use the 7.x versions of NServiceBus 8.1 dependencies, the Functions app needs to be instructed not to remove DLLs it thinks should be included "in the box" since the in-box versions are the 6.x versions.

This fixes an issue with the Functions runtime not being able to load the NServiceBus 8.1 assembly at runtime because it can't find the files for its transitive dependencies.