### PR TITLE
Putting back FunctionExecutionContext

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionExecutionContext.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/FunctionExecutionContext.cs
@@ -1,0 +1,30 @@
+﻿namespace NServiceBus
+{
+    using Microsoft.Azure.WebJobs;
+    using Microsoft.Extensions.Logging;
+
+    /// <summary>
+    /// Contains specific context information of the current function invocation.
+    /// </summary>
+    public class FunctionExecutionContext
+    {
+        /// <summary>
+        /// Creates a new <see cref="FunctionExecutionContext"/>.
+        /// </summary>
+        public FunctionExecutionContext(ExecutionContext executionContext, ILogger logger)
+        {
+            Logger = logger;
+            ExecutionContext = executionContext;
+        }
+
+        /// <summary>
+        /// The <see cref="ExecutionContext"/> associated with the current function invocation.
+        /// </summary>
+        public ExecutionContext ExecutionContext { get; }
+
+        /// <summary>
+        /// The <see cref="ILogger"/> associated with the current function invocation.
+        /// </summary>
+        public ILogger Logger { get; }
+    }
+}

--- a/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/ServiceBus.Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -2,6 +2,12 @@
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(@"ServiceBus.Tests, PublicKey=00240000048000009400000006020000002400005253413100040000010001007f16e21368ff041183fab592d9e8ed37e7be355e93323147a1d29983d6e591b04282e4da0c9e18bd901e112c0033925eb7d7872c2f1706655891c5c9d57297994f707d16ee9a8f40d978f064ee1ffc73c0db3f4712691b23bf596f75130f4ec978cf78757ec034625a5f27e6bb50c618931ea49f6f628fd74271c32959efb1c5")]
 namespace NServiceBus
 {
+    public class FunctionExecutionContext
+    {
+        public FunctionExecutionContext(Microsoft.Azure.WebJobs.ExecutionContext executionContext, Microsoft.Extensions.Logging.ILogger logger) { }
+        public Microsoft.Azure.WebJobs.ExecutionContext ExecutionContext { get; }
+        public Microsoft.Extensions.Logging.ILogger Logger { get; }
+    }
     public static class FunctionsHostBuilderExtensions
     {
         public static void UseNServiceBus(this Microsoft.Azure.Functions.Extensions.DependencyInjection.IFunctionsHostBuilder functionsHostBuilder, System.Action<NServiceBus.ServiceBusTriggeredEndpointConfiguration> configurationFactory = null) { }


### PR DESCRIPTION
Putting back a public class that is no longer used but can't be removed as it would then qualify as breaking changes