### PR TITLE
Add System.Security.Cryptography.Xml to list of preserved dependencies

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
@@ -7,5 +7,6 @@
     <FunctionsPreservedDependencies Include="System.Diagnostics.DiagnosticSource.dll" />
     <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
     <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
+    <FunctionsPreservedDependencies Include="System.Security.Cryptography.Xml.dll" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
@@ -5,8 +5,8 @@
   <ItemGroup>
     <!-- Prevent Functions from removing NServiceBus dependencies that it thinks are included "in the box" -->
     <FunctionsPreservedDependencies Include="System.Diagnostics.DiagnosticSource.dll" />
-    <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
-    <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
     <FunctionsPreservedDependencies Include="System.Security.Cryptography.Xml.dll" />
+    <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
+    <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/issues/769 on `master`.

## Backports

* https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/pull/768 for `release-4.0`
* Bug does not exist in `release-3.0` branch