### PR TITLE
NServiceBus license cannot be loaded due to dependency loading problem with InProcess hosting model

### DIFF
--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
@@ -7,5 +7,6 @@
     <FunctionsPreservedDependencies Include="System.Diagnostics.DiagnosticSource.dll" />
     <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
     <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
+    <FunctionsPreservedDependencies Include="System.Security.Cryptography.Xml.dll" />
   </ItemGroup>
 </Project>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/build/NServiceBus.AzureFunctions.InProcess.ServiceBus.props
@@ -5,8 +5,8 @@
   <ItemGroup>
     <!-- Prevent Functions from removing NServiceBus dependencies that it thinks are included "in the box" -->
     <FunctionsPreservedDependencies Include="System.Diagnostics.DiagnosticSource.dll" />
-    <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
-    <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
     <FunctionsPreservedDependencies Include="System.Security.Cryptography.Xml.dll" />
+    <FunctionsPreservedDependencies Include="System.Text.Encodings.Web.dll" />
+    <FunctionsPreservedDependencies Include="System.Text.Json.dll" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Backport of https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/pull/767 to fix https://github.com/Particular/NServiceBus.AzureFunctions.InProcess.ServiceBus/issues/769 in branch `release-4.3`