### PR TITLE
Lib updates and assembly scanning fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             name: Windows
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             name: Linux
       fail-fast: false
     steps:
@@ -36,7 +36,6 @@ jobs:
         uses: actions/setup-dotnet@v4.0.0
         with:
           dotnet-version: |
-            7.0.x
             6.0.x
       - name: Setup Azure Core tools - Windows
         if: runner.os == 'Windows'

--- a/src/IntegrationTests.HostV4/IntegrationTests.HostV4.csproj
+++ b/src/IntegrationTests.HostV4/IntegrationTests.HostV4.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.4.0" />
-    <PackageReference Include="NServiceBus" Version="8.1.1" />
+    <PackageReference Include="NServiceBus" Version="8.2.1" />
     <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="3.2.3" />
   </ItemGroup>
 

--- a/src/IntegrationTests.HostV4/Startup.cs
+++ b/src/IntegrationTests.HostV4/Startup.cs
@@ -8,6 +8,6 @@ public class Startup : FunctionsStartup
 {
     public override void Configure(IFunctionsHostBuilder builder)
     {
-        builder.UseNServiceBus();
+        builder.UseNServiceBus(c => c.AdvancedConfiguration.EnableInstallers());
     }
 }

--- a/src/NServiceBus.AzureFunctions.Analyzer.Tests/NServiceBus.AzureFunctions.Analyzer.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.Analyzer.Tests/NServiceBus.AzureFunctions.Analyzer.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -138,23 +138,23 @@
         }
 
         internal static readonly string[] AssembliesToExcludeFromScanning = {
-            "NCrontab.Signed.dll",
             "Azure.Core.dll",
-            "Grpc.AspNetCore.Server.dll",
+            "Azure.Identity.dll",
+            "Azure.Security.KeyVault.Secrets.dll",
+            "Azure.Storage.Blobs.dll",
+            "Azure.Storage.Common.dll",
+            "Google.Protobuf.dll",
             "Grpc.AspNetCore.Server.ClientFactory.dll",
+            "Grpc.AspNetCore.Server.dll",
             "Grpc.Core.Api.dll",
-            "Grpc.Net.Common.dll",
             "Grpc.Net.Client.dll",
             "Grpc.Net.ClientFactory.dll",
-            "Google.Protobuf.dll",
-            "Azure.Identity.dll",
+            "Grpc.Net.Common.dll",
             "Microsoft.Extensions.Azure.dll",
-            "NServiceBus.Extensions.DependencyInjection.dll",
             "Microsoft.Identity.Client.dll",
             "Microsoft.Identity.Client.Extensions.Msal.dll",
-            "Azure.Storage.Common.dll",
-            "Azure.Storage.Blobs.dll",
-            "Azure.Security.KeyVault.Secrets.dll"
+            "NCrontab.Signed.dll",
+            "NServiceBus.Extensions.DependencyInjection.dll"
         };
 
         internal async Task InitializeEndpointIfNecessary(CancellationToken cancellationToken)

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/InProcessFunctionEndpoint.cs
@@ -140,10 +140,13 @@
         internal static readonly string[] AssembliesToExcludeFromScanning = {
             "NCrontab.Signed.dll",
             "Azure.Core.dll",
+            "Grpc.AspNetCore.Server.dll",
+            "Grpc.AspNetCore.Server.ClientFactory.dll",
             "Grpc.Core.Api.dll",
             "Grpc.Net.Common.dll",
             "Grpc.Net.Client.dll",
             "Grpc.Net.ClientFactory.dll",
+            "Google.Protobuf.dll",
             "Azure.Identity.dll",
             "Microsoft.Extensions.Azure.dll",
             "NServiceBus.Extensions.DependencyInjection.dll",

--- a/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBus.AzureFunctions.InProcess.ServiceBus.csproj
+++ b/src/NServiceBus.AzureFunctions.InProcess.ServiceBus/NServiceBus.AzureFunctions.InProcess.ServiceBus.csproj
@@ -16,10 +16,10 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.11.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="5.16.0" />
     <PackageReference Include="NServiceBus.Newtonsoft.Json" Version="[3.0.0, 4.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[8.1.1, 9.0.0)" />
-    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[3.0.0, 4.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[8.2.1, 9.0.0)" />
+    <PackageReference Include="NServiceBus.Transport.AzureServiceBus" Version="[3.2.3, 4.0.0)" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="3.0.0" PrivateAssets="All" />
   </ItemGroup>

--- a/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/NServiceBus.AzureFunctions.SourceGenerator.Tests.csproj
+++ b/src/NServiceBus.AzureFunctions.SourceGenerator.Tests/NServiceBus.AzureFunctions.SourceGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/ServiceBus.AcceptanceTests/ServiceBus.AcceptanceTests.csproj
+++ b/src/ServiceBus.AcceptanceTests/ServiceBus.AcceptanceTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/src/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="NServiceBus" Version="8.1.1" />
+    <PackageReference Include="NServiceBus" Version="8.2.1" />
     <PackageReference Include="Particular.Approvals" Version="1.0.0" />
     <PackageReference Include="PublicApiGenerator" Version="11.1.0" />
   </ItemGroup>

--- a/src/ServiceBus.Tests/ServiceBus.Tests.csproj
+++ b/src/ServiceBus.Tests/ServiceBus.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\NServiceBusTests.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/src/Testing.Handlers/Testing.Handlers.csproj
+++ b/src/Testing.Handlers/Testing.Handlers.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This brings project references up to speed to benefit from the latest improvements across the board. It also adjusts the scanning logic to exclude the new assemblies that cannot be scanned.